### PR TITLE
Fixed macro implementation

### DIFF
--- a/src/umock/Mock.hx
+++ b/src/umock/Mock.hx
@@ -39,7 +39,12 @@ class The
 				// To notify Mock.setup() that this is a method call,
 				// return an anonymous method that returns the fieldname as a string.
 				var cPos = Context.currentPos();
-				return { expr: EFunction( {expr: { expr: EReturn( { expr: EConst(CString(f)), pos : cPos } ), pos : cPos }, args: [], ret: null } ), pos: cPos };
+				var fn: Function = { 
+					args: [], ret: TPath({ pack : [], name : "String", params : [], sub : null }), params: [], 
+					expr: {expr: EReturn({expr: EConst(CString(f)), pos: cPos}), pos: cPos}
+				};
+
+				return return { expr: EFunction(null, fn), pos: cPos };
 				
 			default:
 				// If no match, return itself to get intellisense.

--- a/test/umock/TestReturns.hx
+++ b/test/umock/TestReturns.hx
@@ -1,6 +1,8 @@
 package umock;
 
 import haxe.rtti.Infos;
+import haxe.PosInfos;
+
 import utest.Assert;
 
 import umock.Mock;
@@ -30,8 +32,8 @@ class TestReturns
 		Assert.raises(function() { mock.object.length(); }, String);
 		Assert.raises(function() { mock.object.setDate(Date.now()); }, String);
 		#else
-		Assert.isNull(mock.object.length);
-		Assert.isNull(mock.object.setDate);
+		Assert.notNull(mock.object.length);
+		Assert.notNull(mock.object.setDate);
 		#end
 	}
 


### PR DESCRIPTION
In Haxe 2.10, setup with macro is failed.

Fixed it in order to modify EFunction definition.

And in testEmptyObject for js, since mock.object.length and mock.object.date is returned function type, fixed isnull to notnull.
